### PR TITLE
How type safe is too type safe?

### DIFF
--- a/examples/common.rs
+++ b/examples/common.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use linux_embedded_hal::Serial;
-use rn2xx3::Rn2xx3;
+use rn2xx3::{Driver, Rn2483, rn2483};
 use serial::{self, core::SerialPort};
 
-pub fn init_rn(dev: &str) -> Rn2xx3<Serial> {
+pub fn init_rn(dev: &str) -> Driver<Rn2483, Serial> {
     // Serial port settings
     let settings = serial::PortSettings {
         baud_rate: serial::Baud57600,
@@ -22,7 +22,7 @@ pub fn init_rn(dev: &str) -> Rn2xx3<Serial> {
         .expect("Could not set serial port timeout");
 
     // Initialize driver
-    Rn2xx3::new(Serial(port))
+    rn2483(Serial(port))
 }
 
 #[allow(dead_code)]

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use linux_embedded_hal::Serial;
-use rn2xx3::{Driver, Rn2483, rn2483};
+use rn2xx3::{Driver, Freq868, rn2483_868};
 use serial::{self, core::SerialPort};
 
-pub fn init_rn(dev: &str) -> Driver<Rn2483, Serial> {
+pub fn init_rn(dev: &str) -> Driver<Freq868, Serial> {
     // Serial port settings
     let settings = serial::PortSettings {
         baud_rate: serial::Baud57600,
@@ -22,7 +22,7 @@ pub fn init_rn(dev: &str) -> Driver<Rn2483, Serial> {
         .expect("Could not set serial port timeout");
 
     // Initialize driver
-    rn2483(Serial(port))
+    rn2483_868(Serial(port))
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,21 +10,21 @@ const CR: u8 = 0x0d;
 const LF: u8 = 0x0a;
 const OK: [u8; 2] = [b'o', b'k'];
 
-/// Marker trait implemented for all model type parameters.
-pub trait ModelParam {}
-/// Model type parameter for the RN2483 (433 MHz).
+/// Marker trait implemented for all models / frequencies.
+pub trait Frequency {}
+/// Frequency type parameter for the RN2483 (433 MHz).
 pub struct Freq433;
-/// Model type parameter for the RN2483 (868 MHz).
+/// Frequency type parameter for the RN2483 (868 MHz).
 pub struct Freq868;
-/// Model type parameter for the RN2903 (915 MHz).
+/// Frequency type parameter for the RN2903 (915 MHz).
 pub struct Freq915;
-impl ModelParam for Freq433 {}
-impl ModelParam for Freq868 {}
-impl ModelParam for Freq915 {}
+impl Frequency for Freq433 {}
+impl Frequency for Freq868 {}
+impl Frequency for Freq915 {}
 
 /// The main driver instance.
-pub struct Driver<M: ModelParam, S> {
-    model: PhantomData<M>,
+pub struct Driver<F: Frequency, S> {
+    frequency: PhantomData<F>,
     serial: S,
     read_buf: [u8; 64],
 }
@@ -72,7 +72,7 @@ where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
 {
     Driver {
-        model: PhantomData,
+        frequency: PhantomData,
         serial,
         read_buf: [0; 64],
     }
@@ -85,7 +85,7 @@ where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
 {
     Driver {
-        model: PhantomData,
+        frequency: PhantomData,
         serial,
         read_buf: [0; 64],
     }
@@ -98,17 +98,17 @@ where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
 {
     Driver {
-        model: PhantomData,
+        frequency: PhantomData,
         serial,
         read_buf: [0; 64],
     }
 }
 
 /// Basic commands.
-impl<M, S, E> Driver<M, S>
+impl<F, S, E> Driver<F, S>
 where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
-    M: ModelParam,
+    F: Frequency,
 {
     /// Write a single byte to the serial port.
     fn write_byte(&mut self, byte: u8) -> RnResult<()> {
@@ -183,10 +183,10 @@ where
 }
 
 /// System commands.
-impl<M, S, E> Driver<M, S>
+impl<F, S, E> Driver<F, S>
 where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
-    M: ModelParam,
+    F: Frequency,
 {
     /// Reset and restart the RN module. Return the version string.
     pub fn reset(&mut self) -> RnResult<&str> {
@@ -309,10 +309,10 @@ macro_rules! hex_setter {
 }
 
 /// MAC Set Commands.
-impl<M, S, E> Driver<M, S>
+impl<F, S, E> Driver<F, S>
 where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
-    M: ModelParam,
+    F: Frequency,
 {
     hex_setter!(
         "devaddr", 4,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,15 @@ const OK: [u8; 2] = [b'o', b'k'];
 
 /// Marker trait implemented for all model type parameters.
 pub trait ModelParam {}
-/// Model type parameter for the RN2483.
-pub struct Rn2483;
-/// Model type parameter for the RN2903.
-pub struct Rn2903;
-impl ModelParam for Rn2483 {}
-impl ModelParam for Rn2903 {}
+/// Model type parameter for the RN2483 (433 MHz).
+pub struct Freq433;
+/// Model type parameter for the RN2483 (868 MHz).
+pub struct Freq868;
+/// Model type parameter for the RN2903 (915 MHz).
+pub struct Freq915;
+impl ModelParam for Freq433 {}
+impl ModelParam for Freq868 {}
+impl ModelParam for Freq915 {}
 
 /// The main driver instance.
 pub struct Driver<M: ModelParam, S> {
@@ -62,9 +65,22 @@ impl From<Utf8Error> for Error {
     }
 }
 
-/// Create a new driver instance for the RN2483 (433/868 MHz), wrapping the
+/// Create a new driver instance for the RN2483 (433 MHz), wrapping the
 /// specified serial port.
-pub fn rn2483<S, E>(serial: S) -> Driver<Rn2483, S>
+pub fn rn2483_433<S, E>(serial: S) -> Driver<Freq433, S>
+where
+    S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
+{
+    Driver {
+        model: PhantomData,
+        serial,
+        read_buf: [0; 64],
+    }
+}
+
+/// Create a new driver instance for the RN2483 (868 MHz), wrapping the
+/// specified serial port.
+pub fn rn2483_868<S, E>(serial: S) -> Driver<Freq868, S>
 where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
 {
@@ -77,7 +93,7 @@ where
 
 /// Create a new driver instance for the RN2903 (915 MHz), wrapping the
 /// specified serial port.
-pub fn rn2903<S, E>(serial: S) -> Driver<Rn2903, S>
+pub fn rn2903_915<S, E>(serial: S) -> Driver<Freq915, S>
 where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
 {
@@ -341,16 +357,6 @@ where
     );
 }
 
-/// MAC Set Commands (RN2483).
-impl<S, E> Driver<Rn2483, S>
-where
-    S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
-{
-    pub fn set_output_power(&mut self, val: &str) -> RnResult<()> {
-        self.send_raw_command_ok(&["mac set pwridx ", val])
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,7 +375,7 @@ mod tests {
             Transaction::read_many(CRLF.as_bytes()),
         ];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         assert_eq!(rn.version().unwrap(), VERSION48);
         mock.done();
     }
@@ -382,7 +388,7 @@ mod tests {
             Transaction::read_many(CRLF.as_bytes()),
         ];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         assert_eq!(rn.model().unwrap(), Model::RN2483);
         mock.done();
     }
@@ -395,7 +401,7 @@ mod tests {
             Transaction::read_many(CRLF.as_bytes()),
         ];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         assert_eq!(rn.model().unwrap(), Model::RN2903);
         mock.done();
     }
@@ -407,7 +413,7 @@ mod tests {
             Transaction::read_many(b"ok\r\n"),
         ];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         rn.nvm_set(0x3ab, 42).unwrap();
         mock.done();
     }
@@ -419,7 +425,7 @@ mod tests {
             Transaction::read_many(b"ff\r\n"),
         ];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         assert_eq!(rn.nvm_get(0x300).unwrap(), 0xff);
         mock.done();
     }
@@ -430,7 +436,7 @@ mod tests {
     fn set_dev_addr_bad_length() {
         let expectations = [];
         let mut mock = SerialMock::new(&expectations);
-        let mut rn = rn2483(mock.clone());
+        let mut rn = rn2483_868(mock.clone());
         assert_eq!(rn.set_dev_addr_hex("010203f"), Err(Error::BadParameter));
         assert_eq!(rn.set_dev_addr_hex("010203fff"), Err(Error::BadParameter));
         assert_eq!(rn.set_dev_eui_hex("0004a30b001a55e"), Err(Error::BadParameter));
@@ -438,13 +444,13 @@ mod tests {
         mock.done();
     }
 
-    fn _set_dev_addr() -> (SerialMock<u8>, Driver<Rn2483, SerialMock<u8>>) {
+    fn _set_dev_addr() -> (SerialMock<u8>, Driver<Freq868, SerialMock<u8>>) {
         let expectations = [
             Transaction::write_many(b"mac set devaddr 010203ff\r\n"),
             Transaction::read_many(b"ok\r\n"),
         ];
         let mock = SerialMock::new(&expectations);
-        let rn = rn2483(mock.clone());
+        let rn = rn2483_868(mock.clone());
         (mock, rn)
     }
 
@@ -462,13 +468,13 @@ mod tests {
         mock.done();
     }
 
-    fn _set_dev_eui() -> (SerialMock<u8>, Driver<Rn2483, SerialMock<u8>>) {
+    fn _set_dev_eui() -> (SerialMock<u8>, Driver<Freq868, SerialMock<u8>>) {
         let expectations = [
             Transaction::write_many(b"mac set deveui 0004a30b001a55ed\r\n".as_ref()),
             Transaction::read_many(b"ok\r\n"),
         ];
         let mock = SerialMock::new(&expectations);
-        let rn = rn2483(mock.clone());
+        let rn = rn2483_868(mock.clone());
         (mock, rn)
     }
 


### PR DESCRIPTION
While the RN2483 (EU) and RN2903 (US) are mostly identical, there are some values that are acceptable for a RN2483 but not for a RN2903. Furthermore, depending on the frequency chosen for the EU version (433 or 868 MHz), different values are allowed.

For example, the `pwridx` value can be set to 1-5 for the RN2483@868, to 0-5 for the RN2483@433 and 6-10 for the RN2903@915.

```
        EU       433 MHz    US
    0:  N/A       10 dBm    N/A
    1:  14 dBm     7 dBm    N/A
    2:  11 dBm     4 dBm    N/A
    3:   8 dBm     1 dBm    N/A
    4:   5 dBm    -2 dBm    N/A
    5:   2 dBm    -5 dBm   20 dBm
    6:  N/A       N/A      18 dBm
    7:  N/A       N/A      16 dBm
    8:  N/A       N/A      14 dBm
    9:  N/A       N/A      12 dBm
    10: N/A       N/A      10 dBm
```

While we could handle this using validation, we could also handle it using the type system.

For this, I added a type parameter to the driver signature:

```rust
// Old
pub struct Rn2xx3<S> {
    serial: S,
    read_buf: [u8; 64],
}

// New
pub struct Driver<F: Frequency, S> {
    frequency: PhantomData<F>,
    serial: S,
    read_buf: [u8; 64],
}
```

The `Frequency` marker trait is implemented for three frequencies:

```rust
/// Marker trait implemented for all models / frequencies.
pub trait Frequency {}

/// Frequency type parameter for the RN2483 (433 MHz).
pub struct Freq433;
/// Frequency type parameter for the RN2483 (868 MHz).
pub struct Freq868;
/// Frequency type parameter for the RN2903 (915 MHz).
pub struct Freq915;

impl Frequency for Freq433 {}
impl Frequency for Freq868 {}
impl Frequency for Freq915 {}
```

This allows us to implement functions for all models:

```rust
impl<F, S, E> Driver<F, S>
where
    S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
    F: Frequency,
{
    ...
```

...or only for specific models.

```rust
impl<S, E> Driver<Freq868, S>
where
    S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
{
    ...
```

That way we can use enums for certain values that only contain variants which are possible to use.

The main downside would be that the model and frequency plan used would need to be known at compile time. In practice if you'd want to support different frequencies, you would create different versions of the firmware for every frequency used, or create a single firmware containing all three driver variants. But this isn't necessarily a bad thing, it would ensure that mistakes don't happen when configuring values dynamically.

Opinions, @rnestler?