### PR TITLE
Implement sleep mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +214,7 @@ dependencies = [
  "linux-embedded-hal 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -369,6 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum nb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1411551beb3c11dedfb0a90a0fa256b47d28b9ec2cdff34c25a2fa59e45dbdc"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+"checksum numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e521b6adefa0b2c1fa5d2abdf9a5216288686fe6146249215d884c0e5ab320b0"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ doc-comment = "0.3"
 embedded-hal = "0.2"
 log = { version = "0.4", optional = true }
 nb = "0.1"
+numtoa = "0.2"
 
 [dev-dependencies]
 embedded-hal-mock = "0.7"

--- a/examples/sleep.rs
+++ b/examples/sleep.rs
@@ -1,0 +1,46 @@
+mod common;
+
+use std::env;
+use std::time::Duration;
+
+use env_logger;
+use rn2xx3::errors::Error;
+
+fn main() {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        println!("Usage: {} <path-to-serial>", args[0]);
+        println!("Example: {} /dev/ttyUSB0", args[0]);
+        std::process::exit(1);
+    }
+    let mut rn = common::init_rn(&args[1]);
+
+    println!("Resetting module...\n");
+    rn.reset().expect("Could not reset");
+
+    println!("Reading hweui...");
+    let hweui = rn.hweui().expect("Could not read hweui");
+    println!("> HW-EUI: {}", hweui);
+
+    println!("\nPutting module to sleep for 2 seconds...");
+    rn.sleep(Duration::from_secs(2))
+        .expect("Could not enable sleep mode");
+    println!("> Done");
+
+    println!("\nReading hweui...");
+    match rn.hweui().unwrap_err() {
+        Error::SleepMode => println!("> Failed: Module still in sleep mode"),
+        other => println!("> Failed: Unexpected error: {:?}", other),
+    }
+
+    println!("Waiting for wakeup...");
+    rn.wait_for_wakeup(false)
+        .expect("Waiting for wakeup failed");
+    println!("> Ok");
+
+    println!("Reading hweui...");
+    let hweui = rn.hweui().expect("Could not read hweui");
+    println!("> HW-EUI: {}", hweui);
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,8 @@ pub enum Error {
     CommandFailed,
     /// A bad parameter was supplied.
     BadParameter,
+    /// Device is in sleep mode.
+    SleepMode,
 }
 
 impl From<Utf8Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,11 @@ where
     S: serial::Read<u8, Error = E> + serial::Write<u8, Error = E>,
     F: Frequency,
 {
+    /// Destroy this driver instance, return the wrapped serial device.
+    pub fn destroy(self) -> S {
+        self.serial
+    }
+
     /// Reset and restart the RN module. Return the version string.
     pub fn reset(&mut self) -> RnResult<&str> {
         self.send_raw_command_str(&["sys reset"])


### PR DESCRIPTION
Add methods for going to sleep and waiting for wakeup.

Unfortunately we cannot implement the wakeup command, since there is no trait for a break condition: https://github.com/rust-embedded/embedded-hal/issues/190 However, the driver could be destructured using the new `destroy` method and recreated after sending the break condition manually. Waiting for wakeup can then be done in the driver by using `wait_for_wakeup(/* force */ true)`.