### PR TITLE
Get and set data rate

### DIFF
--- a/examples/join_otaa.rs
+++ b/examples/join_otaa.rs
@@ -5,7 +5,7 @@ use std::io::{stdout, Write};
 
 use env_logger;
 
-use rn2xx3::{ConfirmationMode, JoinMode};
+use rn2xx3::{ConfirmationMode, DataRateEuCn, JoinMode};
 
 fn main() {
     env_logger::init();
@@ -39,6 +39,10 @@ fn main() {
     stdout().flush().expect("Could not flush stdout");
     rn.join(JoinMode::Otaa).expect("Could not join");
     println!("OK");
+
+    // Set data rate
+    rn.set_data_rate(DataRateEuCn::Sf9Bw125)
+        .expect("Could not set data rate");
 
     // Send data
     let port: u8 = args[4].parse().expect("Invalid port");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1147,6 +1147,46 @@ mod tests {
         mock.done();
     }
 
+    mod data_rate {
+        use super::*;
+
+        #[test]
+        fn set_sf9_eucn() {
+            let expectations = [
+                Transaction::write_many(b"mac set dr 3\r\n"),
+                Transaction::read_many(b"ok\r\n"),
+            ];
+            let mut mock = SerialMock::new(&expectations);
+            let mut rn = rn2483_868(mock.clone());
+            assert!(rn.set_data_rate(DataRateEuCn::Sf9Bw125).is_ok());
+            mock.done();
+        }
+
+        #[test]
+        fn set_sf9_us() {
+            let expectations = [
+                Transaction::write_many(b"mac set dr 1\r\n"),
+                Transaction::read_many(b"ok\r\n"),
+            ];
+            let mut mock = SerialMock::new(&expectations);
+            let mut rn = rn2903_915(mock.clone());
+            assert!(rn.set_data_rate(DataRateUs::Sf9Bw125).is_ok());
+            mock.done();
+        }
+
+        #[test]
+        fn set_sf12_eucn() {
+            let expectations = [
+                Transaction::write_many(b"mac set dr 0\r\n"),
+                Transaction::read_many(b"ok\r\n"),
+            ];
+            let mut mock = SerialMock::new(&expectations);
+            let mut rn = rn2483_868(mock.clone());
+            assert!(rn.set_data_rate(DataRateEuCn::Sf12Bw125).is_ok());
+            mock.done();
+        }
+    }
+
     mod sleep {
         use super::*;
 


### PR DESCRIPTION
Implement `mac get dr` and `mac set dr <dataRate>` commands.

Data rates taken from https://blog.dbrgn.ch/2017/6/23/lorawan-data-rates/.