### PR TITLE
Rename `destroy` method to `free`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+### Unreleased
+
+- [changed] Rename `destroy` method to `free`
+
 ### v0.1.4 (2020-04-15)
 
 - [added] Optional logging, enabled through Cargo feature (#7)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # RN2xx3
 //!
 //! A `no_std` / `embedded_hal` compatible Rust driver for the RN2483 and
-//! the RN2903 LoRaWAN modules. The library will not do any dynamic allocations.
+//! the RN2903 LoRaWAN modules. The library works without any dynamic allocations.
 //!
 //! ## Usage
 //!
@@ -499,7 +499,7 @@ where
     F: Frequency,
 {
     /// Destroy this driver instance, return the wrapped serial device.
-    pub fn destroy(self) -> S {
+    pub fn free(self) -> S {
         self.serial
     }
 


### PR DESCRIPTION
This matches the `C-FREE` recommendation [here](https://jonas-schievink.github.io/hal-guidelines/interoperability.html).