### PR TITLE
Expose low level serial errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,13 +2,16 @@
 
 use core::str::Utf8Error;
 
+/// A response could not be parsed.
+pub struct ParsingError {}
+
 /// A collection of errors that can occur.
 #[derive(Debug, PartialEq, Eq)]
-pub enum Error {
+pub enum Error<SerialError> {
     /// Could not read from serial port.
-    SerialRead,
+    SerialRead(SerialError),
     /// Could not write to serial port.
-    SerialWrite,
+    SerialWrite(SerialError),
     /// Read buffer is too small.
     /// This is a bug, please report it on GitHub!
     ReadBufferTooSmall,
@@ -26,15 +29,21 @@ pub enum Error {
     InvalidState,
 }
 
-impl From<Utf8Error> for Error {
+impl<SerialError> From<Utf8Error> for Error<SerialError> {
     fn from(_: Utf8Error) -> Self {
         Error::EncodingError
     }
 }
 
+impl<SerialError> From<ParsingError> for Error<SerialError> {
+    fn from(_: ParsingError) -> Self {
+        Error::ParsingError
+    }
+}
+
 /// Errors that can occur during the join procedure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum JoinError {
+pub enum JoinError<SerialError> {
     /// Invalid join mode. This indicates a bug in the driver and should be
     /// reported on GitHub.
     BadParameter,
@@ -55,16 +64,16 @@ pub enum JoinError {
     /// Unknown response.
     UnknownResponse,
     /// Another error occurred.
-    Other(Error),
+    Other(Error<SerialError>),
 }
 
-impl From<Error> for JoinError {
-    fn from(other: Error) -> Self {
+impl<SerialError> From<Error<SerialError>> for JoinError<SerialError> {
+    fn from(other: Error<SerialError>) -> Self {
         JoinError::Other(other)
     }
 }
 
-impl From<Utf8Error> for JoinError {
+impl<SerialError> From<Utf8Error> for JoinError<SerialError> {
     fn from(_: Utf8Error) -> Self {
         JoinError::Other(Error::EncodingError)
     }
@@ -72,7 +81,7 @@ impl From<Utf8Error> for JoinError {
 
 /// Errors that can occur during the transmit procedure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum TxError {
+pub enum TxError<SerialError> {
     /// Invalid type, port or data.
     BadParameter,
     /// Network not joined.
@@ -95,20 +104,20 @@ pub enum TxError {
     /// Unknown response.
     UnknownResponse,
     /// Another error occurred.
-    Other(Error),
+    Other(Error<SerialError>),
 }
 
-impl From<Error> for TxError {
-    fn from(other: Error) -> Self {
+impl<SerialError> From<Error<SerialError>> for TxError<SerialError> {
+    fn from(other: Error<SerialError>) -> Self {
         TxError::Other(other)
     }
 }
 
-impl From<Utf8Error> for TxError {
+impl<SerialError> From<Utf8Error> for TxError<SerialError> {
     fn from(_: Utf8Error) -> Self {
         TxError::Other(Error::EncodingError)
     }
 }
 
 /// A `Result<T, Error>`.
-pub type RnResult<T> = Result<T, Error>;
+pub type RnResult<T, SerialError> = Result<T, Error<SerialError>>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,11 +4,11 @@ use core::str::Utf8Error;
 
 /// A collection of errors that can occur.
 #[derive(Debug, PartialEq, Eq)]
-pub enum Error<SerialError> {
+pub enum Error<S> {
     /// Could not read from serial port.
-    SerialRead(SerialError),
+    SerialRead(S),
     /// Could not write to serial port.
-    SerialWrite(SerialError),
+    SerialWrite(S),
     /// Read buffer is too small.
     /// This is a bug, please report it on GitHub!
     ReadBufferTooSmall,
@@ -26,7 +26,7 @@ pub enum Error<SerialError> {
     InvalidState,
 }
 
-impl<SerialError> From<Utf8Error> for Error<SerialError> {
+impl<S> From<Utf8Error> for Error<S> {
     fn from(_: Utf8Error) -> Self {
         Error::EncodingError
     }
@@ -34,7 +34,7 @@ impl<SerialError> From<Utf8Error> for Error<SerialError> {
 
 /// Errors that can occur during the join procedure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum JoinError<SerialError> {
+pub enum JoinError<S> {
     /// Invalid join mode. This indicates a bug in the driver and should be
     /// reported on GitHub.
     BadParameter,
@@ -55,16 +55,16 @@ pub enum JoinError<SerialError> {
     /// Unknown response.
     UnknownResponse,
     /// Another error occurred.
-    Other(Error<SerialError>),
+    Other(Error<S>),
 }
 
-impl<SerialError> From<Error<SerialError>> for JoinError<SerialError> {
-    fn from(other: Error<SerialError>) -> Self {
+impl<S> From<Error<S>> for JoinError<S> {
+    fn from(other: Error<S>) -> Self {
         JoinError::Other(other)
     }
 }
 
-impl<SerialError> From<Utf8Error> for JoinError<SerialError> {
+impl<S> From<Utf8Error> for JoinError<S> {
     fn from(_: Utf8Error) -> Self {
         JoinError::Other(Error::EncodingError)
     }
@@ -72,7 +72,7 @@ impl<SerialError> From<Utf8Error> for JoinError<SerialError> {
 
 /// Errors that can occur during the transmit procedure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum TxError<SerialError> {
+pub enum TxError<S> {
     /// Invalid type, port or data.
     BadParameter,
     /// Network not joined.
@@ -95,20 +95,20 @@ pub enum TxError<SerialError> {
     /// Unknown response.
     UnknownResponse,
     /// Another error occurred.
-    Other(Error<SerialError>),
+    Other(Error<S>),
 }
 
-impl<SerialError> From<Error<SerialError>> for TxError<SerialError> {
-    fn from(other: Error<SerialError>) -> Self {
+impl<S> From<Error<S>> for TxError<S> {
+    fn from(other: Error<S>) -> Self {
         TxError::Other(other)
     }
 }
 
-impl<SerialError> From<Utf8Error> for TxError<SerialError> {
+impl<S> From<Utf8Error> for TxError<S> {
     fn from(_: Utf8Error) -> Self {
         TxError::Other(Error::EncodingError)
     }
 }
 
 /// A `Result<T, Error>`.
-pub type RnResult<T, SerialError> = Result<T, Error<SerialError>>;
+pub type RnResult<T, S> = Result<T, Error<S>>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,9 +2,6 @@
 
 use core::str::Utf8Error;
 
-/// A response could not be parsed.
-pub struct ParsingError {}
-
 /// A collection of errors that can occur.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error<SerialError> {
@@ -32,12 +29,6 @@ pub enum Error<SerialError> {
 impl<SerialError> From<Utf8Error> for Error<SerialError> {
     fn from(_: Utf8Error) -> Self {
         Error::EncodingError
-    }
-}
-
-impl<SerialError> From<ParsingError> for Error<SerialError> {
-    fn from(_: ParsingError) -> Self {
-        Error::ParsingError
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ use core::fmt;
 #[cfg(feature = "logging")]
 use log;
 
-use crate::errors::{Error, JoinError, ParsingError, RnResult, TxError};
+use crate::errors::{Error, JoinError, RnResult, TxError};
 
 const CR: u8 = 0x0d;
 const LF: u8 = 0x0a;
@@ -295,7 +295,7 @@ impl From<DataRateEuCn> for &str {
 }
 
 impl TryFrom<&str> for DataRateEuCn {
-    type Error = ParsingError;
+    type Error = ();
     fn try_from(val: &str) -> Result<Self, Self::Error> {
         match val {
             "0" => Ok(DataRateEuCn::Sf12Bw125),
@@ -305,7 +305,7 @@ impl TryFrom<&str> for DataRateEuCn {
             "4" => Ok(DataRateEuCn::Sf8Bw125),
             "5" => Ok(DataRateEuCn::Sf7Bw125),
             "6" => Ok(DataRateEuCn::Sf7Bw250),
-            _ => Err(ParsingError {}),
+            _ => Err(()),
         }
     }
 }
@@ -342,7 +342,7 @@ impl From<DataRateUs> for &str {
 }
 
 impl TryFrom<&str> for DataRateUs {
-    type Error = ParsingError;
+    type Error = ();
     fn try_from(val: &str) -> Result<Self, Self::Error> {
         match val {
             "0" => Ok(DataRateUs::Sf10Bw125),
@@ -350,7 +350,7 @@ impl TryFrom<&str> for DataRateUs {
             "2" => Ok(DataRateUs::Sf8Bw125),
             "3" => Ok(DataRateUs::Sf7Bw125),
             "4" => Ok(DataRateUs::Sf8Bw500),
-            _ => Err(ParsingError {}),
+            _ => Err(()),
         }
     }
 }
@@ -414,7 +414,7 @@ where
     /// **Note:** For performance reasons, the `sleep` flag is not being
     /// checked here. Make sure not to call this method while in sleep mode.
     fn write_byte(&mut self, byte: u8) -> RnResult<(), E> {
-        block!(self.serial.write(byte)).map_err(|e| Error::SerialWrite(e))
+        block!(self.serial.write(byte)).map_err(Error::SerialWrite)
     }
 
     /// Ensure that the device is not currently in sleep mode.
@@ -446,7 +446,7 @@ where
 
     /// Read a single byte from the serial port.
     fn read_byte(&mut self) -> RnResult<u8, E> {
-        block!(self.serial.read()).map_err(|e| Error::SerialRead(e))
+        block!(self.serial.read()).map_err(Error::SerialRead)
     }
 
     /// Read a CR/LF terminated line from the serial port.
@@ -1035,7 +1035,7 @@ where
     /// Return the currently configured data rate.
     pub fn get_data_rate(&mut self) -> RnResult<DataRateEuCn, E> {
         let dr = self.send_raw_command_str(&["mac get dr"])?;
-        Ok(DataRateEuCn::try_from(dr)?)
+        DataRateEuCn::try_from(dr).map_err(|_| Error::ParsingError)
     }
 }
 
@@ -1052,7 +1052,7 @@ where
     /// Return the currently configured data rate.
     pub fn get_data_rate(&mut self) -> RnResult<DataRateEuCn, E> {
         let dr = self.send_raw_command_str(&["mac get dr"])?;
-        Ok(DataRateEuCn::try_from(dr)?)
+        DataRateEuCn::try_from(dr).map_err(|_| Error::ParsingError)
     }
 }
 
@@ -1069,7 +1069,7 @@ where
     /// Return the currently configured data rate.
     pub fn get_data_rate(&mut self) -> RnResult<DataRateUs, E> {
         let dr = self.send_raw_command_str(&["mac get dr"])?;
-        Ok(DataRateUs::try_from(dr)?)
+        DataRateUs::try_from(dr).map_err(|_| Error::ParsingError)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::errors::{Error, RnResult};
 /// Convert a byte to a decimal string.
 ///
 /// If the buffer is too small, `Error::BadParameter` is returned.
-pub(crate) fn u8_to_str(val: u8, buf: &mut [u8]) -> RnResult<&str> {
+pub(crate) fn u8_to_str<SerialError>(val: u8, buf: &mut [u8]) -> RnResult<&str, SerialError> {
     let chars = match val {
         0..=9 => 1,
         10..=99 => 2,
@@ -75,7 +75,7 @@ mod tests {
         fn all_digits() {
             let mut buf = [0; 3];
             for i in 0..=255 {
-                let string = u8_to_str(i, &mut buf).unwrap();
+                let string = u8_to_str::<()>(i, &mut buf).unwrap();
                 assert_eq!(string, &std::format!("{}", i));
             }
         }
@@ -86,14 +86,14 @@ mod tests {
             let mut buf2 = [0; 2];
             let mut buf3 = [0; 3];
 
-            assert!(u8_to_str(9, &mut buf1).is_ok());
-            assert_eq!(u8_to_str(10, &mut buf1), Err(Error::BadParameter));
+            assert!(u8_to_str::<()>(9, &mut buf1).is_ok());
+            assert_eq!(u8_to_str::<()>(10, &mut buf1), Err(Error::BadParameter));
 
-            assert!(u8_to_str(99, &mut buf2).is_ok());
-            assert_eq!(u8_to_str(100, &mut buf2), Err(Error::BadParameter));
+            assert!(u8_to_str::<()>(99, &mut buf2).is_ok());
+            assert_eq!(u8_to_str::<()>(100, &mut buf2), Err(Error::BadParameter));
 
-            assert!(u8_to_str(255, &mut buf3).is_ok());
-            assert_eq!(u8_to_str(255, &mut buf2), Err(Error::BadParameter));
+            assert!(u8_to_str::<()>(255, &mut buf3).is_ok());
+            assert_eq!(u8_to_str::<()>(255, &mut buf2), Err(Error::BadParameter));
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::errors::{Error, RnResult};
 /// Convert a byte to a decimal string.
 ///
 /// If the buffer is too small, `Error::BadParameter` is returned.
-pub(crate) fn u8_to_str<SerialError>(val: u8, buf: &mut [u8]) -> RnResult<&str, SerialError> {
+pub(crate) fn u8_to_str<S>(val: u8, buf: &mut [u8]) -> RnResult<&str, S> {
     let chars = match val {
         0..=9 => 1,
         10..=99 => 2,


### PR DESCRIPTION
It is hard to debug if one doesn't know what went wrong.

So this allows to expose the low level serial errors in `errors::Error`. The downside is, that now almost everything must be generic on the `SerialError` type, which leads to some quite weird API's in some places.